### PR TITLE
fix#26 - Replace BrowserModule by CommonModule

### DIFF
--- a/src/schema-form/schema-form.module.ts
+++ b/src/schema-form/schema-form.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from "@angular/core";
-import { BrowserModule } from "@angular/platform-browser";
+import { CommonModule } from "@angular/common";
 import {
   FormsModule,
   ReactiveFormsModule
@@ -23,7 +23,7 @@ import {
 } from "./defaultwidgets";
 
 @NgModule({
-  imports : [BrowserModule, FormsModule, ReactiveFormsModule],
+  imports : [CommonModule, FormsModule, ReactiveFormsModule],
   declarations: [
     FormElementComponent,
     FormComponent,


### PR DESCRIPTION
As stated in #26 , a feature module should only import CommonModule and not the whole BrowserModule which belong to only the main App module of a web application
