### PR TITLE
Fix #20 - read only not working properly

### DIFF
--- a/src/schema-form/defaultwidgets/checkbox/checkbox.widget.html
+++ b/src/schema-form/defaultwidgets/checkbox/checkbox.widget.html
@@ -3,12 +3,11 @@
         {{ schema.title }}
     </label>
     <span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>
-	<div class="checkbox">
-		<label class="horizontal control-label">
-			<input [formControl]="control" [attr.name]="name" [indeterminate]="control.value !== false && control.value !== true ? true :null" type="checkbox" [attr.disabled]="schema.readOnly">
+    <div class="checkbox">
+        <label class="horizontal control-label">
+			<input [formControl]="control" [attr.name]="name" [indeterminate]="control.value !== false && control.value !== true ? true :null" type="checkbox">
 			<input *ngIf="schema.readOnly" [attr.name]="name" type="hidden" [formControl]="control">
 			{{schema.description}}
 		</label>
-	</div>
+    </div>
 </div>
-

--- a/src/schema-form/defaultwidgets/file/file.widget.html
+++ b/src/schema-form/defaultwidgets/file/file.widget.html
@@ -1,9 +1,9 @@
 <!-- Support number and range -->
 <div class="widget form-group">
-	<label [attr.for]="id" class="horizontal control-label">
+    <label [attr.for]="id" class="horizontal control-label">
 		{{ schema.title }}
 	</label>
     <span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>
-	<input [name]="name" class="text-widget file-widget" [attr.id]="id" [formControl]="control" type="file" [attr.disabled]="schema.readOnly?true:null" >
-	<input *ngIf="schema.readOnly" [attr.name]="name" type="hidden" [formControl]="control">
+    <input [name]="name" class="text-widget file-widget" [attr.id]="id" [formControl]="control" type="file">
+    <input *ngIf="schema.readOnly" [attr.name]="name" type="hidden" [formControl]="control">
 </div>

--- a/src/schema-form/defaultwidgets/radio/radio.widget.html
+++ b/src/schema-form/defaultwidgets/radio/radio.widget.html
@@ -1,11 +1,11 @@
 <div class="widget form-group">
-	<label>{{schema.title}}</label>
+    <label>{{schema.title}}</label>
     <span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>
-	<div *ngFor="let option of schema.oneOf" class="radio">
-		<label class="horizontal control-label">
-			<input [formControl]="control" [attr.name]="name" value="{{option.enum[0]}}" type="radio"  [attr.disabled]="schema.readOnly">
+    <div *ngFor="let option of schema.oneOf" class="radio">
+        <label class="horizontal control-label">
+			<input [formControl]="control" [attr.name]="name" value="{{option.enum[0]}}" type="radio">
 			{{option.description}}
 		</label>
-	</div>
-	<input *ngIf="schema.readOnly" [attr.name]="name" type="hidden" [formControl]="control">
+    </div>
+    <input *ngIf="schema.readOnly" [attr.name]="name" type="hidden" [formControl]="control">
 </div>

--- a/src/schema-form/defaultwidgets/range/range.widget.html
+++ b/src/schema-form/defaultwidgets/range/range.widget.html
@@ -1,9 +1,8 @@
 <div class="widget form-group">
-	<label [attr.for]="id" class="horizontal control-label">
+    <label [attr.for]="id" class="horizontal control-label">
 		{{ schema.title }}
 	</label>
-    <span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>	
-	<input [name]="name" class="text-widget range-widget" [attr.id]="id"
-	[formControl]="control" [attr.type]="'range'" [attr.min]="schema.minimum" [attr.max]="schema.maximum" [attr.disabled]="schema.readOnly?true:null" >
-	<input *ngIf="schema.readOnly" [attr.name]="name" type="hidden">
+    <span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>
+    <input [name]="name" class="text-widget range-widget" [attr.id]="id" [formControl]="control" [attr.type]="'range'" [attr.min]="schema.minimum" [attr.max]="schema.maximum">
+    <input *ngIf="schema.readOnly" [attr.name]="name" type="hidden">
 </div>

--- a/src/schema-form/defaultwidgets/select/select.widget.html
+++ b/src/schema-form/defaultwidgets/select/select.widget.html
@@ -1,10 +1,10 @@
 <div class="widget form-group">
-	<label [attr.for]="id" class="horizontal control-label">
+    <label [attr.for]="id" class="horizontal control-label">
 		{{ schema.title }}
 	</label>
     <span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>
-	<select [formControl]="control" [attr.name]="name" [attr.disabled]="schema.readOnly" class="form-control">
-	<option *ngFor="let option of schema.oneOf" [ngValue]="option.enum[0]" >{{option.description}}</option>
+    <select [formControl]="control" [attr.name]="name" class="form-control">
+	    <option *ngFor="let option of schema.oneOf" [ngValue]="option.enum[0]" >{{option.description}}</option>
 	</select>
-	<input *ngIf="schema.readOnly" [attr.name]="name" type="hidden" [formControl]="control">
+    <input *ngIf="schema.readOnly" [attr.name]="name" type="hidden" [formControl]="control">
 </div>

--- a/src/schema-form/defaultwidgets/string/string.widget.html
+++ b/src/schema-form/defaultwidgets/string/string.widget.html
@@ -3,6 +3,6 @@
     	{{ schema.title }}
     </label>
     <span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>
-    <input [name]="name" [attr.readonly]="(schema.widget.id!=='color') && schema.readOnly?true:null"  class="text-widget.id textline-widget form-control" [attr.type]="this.getInputType()" [attr.id]="id"  [formControl]="control" [attr.placeholder]="schema.placeholder" [attr.disabled]="(schema.widget.id=='color' && schema.readOnly)?true:null">
+    <input [name]="name" [attr.readonly]="(schema.widget.id!=='color') && schema.readOnly?true:null" class="text-widget.id textline-widget form-control" [attr.type]="this.getInputType()" [attr.id]="id" [formControl]="control" [attr.placeholder]="schema.placeholder">
     <input *ngIf="(schema.widget.id==='color' && schema.readOnly)" [attr.name]="name" type="hidden" [formControl]="control">
 </div>

--- a/src/schema-form/formelement.component.ts
+++ b/src/schema-form/formelement.component.ts
@@ -67,7 +67,8 @@ export class FormElementComponent implements OnInit {
     this.widget.schema = this.formProperty.schema;
     this.widget.name = id;
     this.widget.id = id;
-    this.widget.control = this.control = new FormControl({value: '', disabled: widget.schema.readOnly}, () => null);
+    this.widget.control = this.control;
+    this.widget.control.reset({value: '', disabled: widget.schema.readOnly});
   }
 
 }

--- a/src/schema-form/formelement.component.ts
+++ b/src/schema-form/formelement.component.ts
@@ -67,7 +67,7 @@ export class FormElementComponent implements OnInit {
     this.widget.schema = this.formProperty.schema;
     this.widget.name = id;
     this.widget.id = id;
-    this.widget.control = this.control;
+    this.widget.control = this.control = new FormControl({value: '', disabled: widget.schema.readOnly}, () => null);
   }
 
 }


### PR DESCRIPTION
Should fix #20 .
Our main issue was the use of an input disabled attribute in widget template while they depend on a controller.
I think we might need to rethink the way we handle widgets controlling.
As we depend on a schema as an input, is it still relevant to use Angular FormController?

It seems to work from my manual testing but It could really use a second check.
I'm not even sure FormElementComponent is the right place to do this.
