### PR TITLE
Added a command to package.json to install peer dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,9 +468,8 @@ npm install
 You also need the peer dependencies:
 
 ```bash
-npm info . peerDependencies | sed -n 's/^{\{0,1\}[[:space:]]*'\''\{0,1\}\([^:'\'']*\)'\''\{0,1\}:[[:space:]]'\''\([^'\'']*\).*$/\1@\2/p' | xargs npm i
+npm run install:peers
 ```
-(you may also use install-peerdeps, but I h'avn't figured out how it works)
 
 Then you can build:
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "cd tests/src/app && ln -s ../../../src/ ./lib && cd ../.. && ng test --single-run",
     "build:aot": "ngc -p tsconfig.json",
     "build:jit": "tsc -p tsconfig.json",
-    "build": "npm run clean && npm run build:aot"
+    "build": "npm run clean && npm run build:aot",
+    "install:peers": "npm-install-peers"
   },
   "repository": {
     "type": "git",
@@ -42,6 +43,7 @@
   },
   "peerDependencies": {
     "@angular/common": "^2.4.0",
+    "@angular/forms": "^2.4.0",
     "@angular/compiler": "^2.4.0",
     "@angular/core": "^2.4.0",
     "@angular/http": "^2.4.0",
@@ -56,6 +58,7 @@
     "@angular/platform-server": "^2.4.0",
     "@types/jasmine": "2.5.38",
     "@types/node": "6.0.60",
+    "npm-install-peers": "^1.1.0",
     "rimraf": "^2.5.4"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "moduleResolution": "node",
         "declaration": true,
         "noImplicitAny": false,
-        "strictNullChecks": true,
+        "strictNullChecks": false,
         "sourceMap": false,
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
@@ -33,7 +33,8 @@
         "dist",
         "tests",
         "**/*.ngfactory.ts",
-        "**/*.shim.ts"
+        "**/*.shim.ts",
+        "**/*.spec.ts"
     ],
     "angularCompilerOptions": {
         "genDir": "dist",


### PR DESCRIPTION
I found the package [npm-install-peers](https://github.com/spatie/npm-install-peers) which relies on the  peerDependencies located in the package.json (whereas `npm info` looks at the peerDependencies in the npm registry, which are not always up to date with the git repository).
@ebrehault, @SBats, if you think it is not relevant, do not hesitate to close this PR.

I also added   ` "@angular/forms": "^2.4.0" ` which is required for building.