### PR TITLE
hidden empty visibleIfs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,17 @@ export class AppComponent {
   }
 }
 ```
+Assigning an empty Object to 'visibleIf' is interpreted as _visibleIf_ nothing, thereby the widget is hidden.
+```js
+mySchema = {
+    "properties": {
+      "hidden": {
+        "type": "boolean",
+        "visibleIf": { }
+      }
+    }
+  }
+```
 
 ### Fields presentation and ordering
 As a JSON object is an unordered collection you can't be sure your fields will be correctly ordered when the form is built.

--- a/src/model/formproperty.ts
+++ b/src/model/formproperty.ts
@@ -172,7 +172,11 @@ export abstract class FormProperty {
   // A field is visible if AT LEAST ONE of the properties it depends on is visible AND has a value in the list
   public _bindVisibility() {
     let visibleIf = this.schema.visibleIf;
-    if (visibleIf !== undefined) {
+    if (visibleIf === {})
+    {
+      this.setVisible(false);
+    }
+    else if (visibleIf !== undefined) {
       let propertiesBinding = [];
       for (let dependencyPath in visibleIf) {
         if (visibleIf.hasOwnProperty(dependencyPath)) {

--- a/src/model/formproperty.ts
+++ b/src/model/formproperty.ts
@@ -172,7 +172,7 @@ export abstract class FormProperty {
   // A field is visible if AT LEAST ONE of the properties it depends on is visible AND has a value in the list
   public _bindVisibility() {
     let visibleIf = this.schema.visibleIf;
-    if (visibleIf === {})
+    if (typeof visibleIf === 'object' && Object.keys(visibleIf).length === 0)
     {
       this.setVisible(false);
     }


### PR DESCRIPTION
This hides widgets with a visibleIf field with an empty Object like:

"registerNewsletter": {
        "type": "boolean",
        "description": "I want to receive the newsletter",
        "default": false,
         "visibleIf": { }
     }

As discussed in Issue #102 

I also added an example to the readme. This might be a bit overkill. 

Also this change should be tested as it has the potential to break some peoples forms if I made a mistake. I don't have enough test examples.