### PR TITLE
Allow providing SchemaValidatorFactory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,7 @@ export { FormElementComponent } from './formelement.component';
 export { WidgetChooserComponent } from './widgetchooser.component';
 export { WidgetRegistry } from './widgetregistry';
 export { Validator } from './model/validator';
-export { TerminatorService } from './terminator.service';
-
+export { SchemaValidatorFactory, ZSchemaValidatorFactory } from './schemavalidatorfactory';
 export {
     Widget,
     ControlWidget,

--- a/src/schema-form.module.ts
+++ b/src/schema-form.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   FormsModule,
@@ -23,6 +23,10 @@ import {
 import {
   DefaultWidget
 } from './default.widget';
+
+import { WidgetRegistry } from './widgetregistry';
+import { DefaultWidgetRegistry } from './defaultwidgets';
+import { SchemaValidatorFactory, ZSchemaValidatorFactory } from './schemavalidatorfactory';
 
 @NgModule({
   imports : [CommonModule, FormsModule, ReactiveFormsModule],
@@ -73,4 +77,22 @@ import {
     StringWidget
   ]
 })
-export class SchemaFormModule {}
+export class SchemaFormModule {
+
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: SchemaFormModule,
+      providers: [
+        {
+          provide: WidgetRegistry,
+          useClass: DefaultWidgetRegistry
+        },
+        {
+          provide: SchemaValidatorFactory,
+          useClass: ZSchemaValidatorFactory
+        }
+      ]
+    }
+  }
+
+}

--- a/src/schemavalidatorfactory.ts
+++ b/src/schemavalidatorfactory.ts
@@ -6,7 +6,7 @@ export abstract class SchemaValidatorFactory {
 
 export class ZSchemaValidatorFactory extends SchemaValidatorFactory {
 
-  private zschema;
+  protected zschema;
 
   constructor() {
     super();


### PR DESCRIPTION
This PR adds support to provide custom `SchemaValidatorFactory`.

At the same time, I've added `SchemaFormModule.forRoot()` wich returns module with default providers (providing both WidgetFactory and SchemaValidatorFactory)