### PR TITLE
Updated Object Widget Description Property. Angular Version, Zone.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,20 +42,21 @@
     "z-schema": "^3.17.0"
   },
   "peerDependencies": {
-    "@angular/common": "^4.0.3",
-    "@angular/forms": "^4.0.3",
-    "@angular/compiler": "^4.0.3",
-    "@angular/core": "^4.0.3",
-    "@angular/http": "^4.0.3",
-    "@angular/platform-browser": "^4.0.3",
+    "@angular/animations": "^4.2.5",
+    "@angular/common": "^4.2.5",
+    "@angular/forms": "^4.2.5",
+    "@angular/compiler": "^4.2.5",
+    "@angular/core": "^4.2.5",
+    "@angular/http": "^4.2.5",
+    "@angular/platform-browser": "^4.2.5",
     "core-js": "2.4.1",
     "rxjs": "^5.1.0",
     "typescript": "2.2.2",
-    "zone.js": "^0.7.6"
+    "zone.js": "^0.8.4"
   },
   "devDependencies": {
-    "@angular/compiler-cli": "^4.0.3",
-    "@angular/platform-server": "^4.0.3",
+    "@angular/compiler-cli": "^4.2.5",
+    "@angular/platform-server": "^4.2.5",
     "@types/jasmine": "2.5.38",
     "@types/node": "6.0.60",
     "npm-install-peers": "^1.1.0",

--- a/src/defaultwidgets/object/object.widget.ts
+++ b/src/defaultwidgets/object/object.widget.ts
@@ -6,6 +6,7 @@ import { ObjectLayoutWidget } from '../../widget';
   selector: 'sf-form-object',
   template: `<fieldset *ngFor="let fieldset of formProperty.schema.fieldsets">
 	<legend *ngIf="fieldset.title">{{fieldset.title}}</legend>
+	<div *ngIf="fieldset.description">{{fieldset.description}}</div>
 	<div *ngFor="let fieldId of fieldset.fields">
 		<sf-form-element [formProperty]="formProperty.getProperty(fieldId)"></sf-form-element>
 	</div>

--- a/src/model/schemapreprocessor.ts
+++ b/src/model/schemapreprocessor.ts
@@ -88,7 +88,8 @@ export class SchemaPreprocessor {
   private static replaceOrderByFieldsets(jsonSchema) {
     jsonSchema.fieldsets = [{
       id: 'fieldset-default',
-      title: jsonSchema.description || '',
+      title: jsonSchema.title || '',
+      description : jsonSchema.description || '',
       fields: jsonSchema.order
     }];
     delete jsonSchema.order;

--- a/src/model/schemapreprocessor.ts
+++ b/src/model/schemapreprocessor.ts
@@ -90,6 +90,7 @@ export class SchemaPreprocessor {
       id: 'fieldset-default',
       title: jsonSchema.title || '',
       description : jsonSchema.description || '',
+      name : jsonSchema.name || '',
       fields: jsonSchema.order
     }];
     delete jsonSchema.order;


### PR DESCRIPTION
Two main changes were made

## Object Property Description
The object widget now has a description title. 
The title properties then goes for the legend element. 

The _fieldset_ created within the object widget 
did contain the _description_ of the json schema element as a legend but not the _title_.
So when in json schema element both properties, _title_ and _description_, where set,
then only the description were visible.

Also the _name_ property of the schema element will be passed to the fieldset instance,
but it will not be rendered into the template.

## Angular 4.0.3
To make the project work with angular version ^4.0.3 zone had to be updated.

would be glad to see this coming