### PR TITLE
added support for hidden field by using widget id 'hidden'

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,37 @@ mySchema = {
   }
 ```
 
+#### Hidden fields
+When a field has been made invisible by the condition `visibleIf`
+then the property of the invisible field will be missing in the result model.
+
+If there is need to submit default values that are not visible for the form
+the `widget.id` `hidden` might be the better choice
+```js
+  mySchema = {
+    "properties": {
+      "hiddenInput": {
+        "type": "boolean",
+        "widget": "hidden",
+        "default": true
+      },
+      "lastName": {
+        "type": "string",
+        ...
+      }
+    }
+  }
+```
+so the value of the hidden field will be bound to the output model
+
+```js
+  {
+    "hiddenInput": true,
+    "lastName": "Doe",
+    ...
+  }
+```
+
 ### Fields presentation and ordering
 As a JSON object is an unordered collection you can't be sure your fields will be correctly ordered when the form is built.
 The `order` and `fieldsets` entries of the schema are here to organize your fields.

--- a/src/defaultwidgets/string/string.widget.ts
+++ b/src/defaultwidgets/string/string.widget.ts
@@ -4,14 +4,17 @@ import { ControlWidget } from '../../widget';
 
 @Component({
   selector: 'sf-string-widget',
-  template: `<div class="widget form-group">
+  template: `<input *ngIf="this.getInputType()==='hidden'; else notHiddenFieldBlock" [attr.name]="name" type="hidden" [formControl]="control">
+<ng-template #notHiddenFieldBlock>
+<div class="widget form-group">
     <label [attr.for]="id" class="horizontal control-label">
     	{{ schema.title }}
     </label>
     <span *ngIf="schema.description" class="formHelp">{{schema.description}}</span>
     <input [name]="name" [attr.readonly]="(schema.widget.id!=='color') && schema.readOnly?true:null"  class="text-widget.id textline-widget form-control" [attr.type]="this.getInputType()" [attr.id]="id"  [formControl]="control" [attr.placeholder]="schema.placeholder" [attr.disabled]="(schema.widget.id=='color' && schema.readOnly)?true:null">
     <input *ngIf="(schema.widget.id==='color' && schema.readOnly)" [attr.name]="name" type="hidden" [formControl]="control">
-</div>`
+</div>
+</ng-template>`
 })
 export class StringWidget extends ControlWidget {
 


### PR DESCRIPTION
Support for INPUT TYPE HIDDEN.

This pull request solves the lack of hidden fields that are bound to the output model.
In contrast to the conditional field visibility via the `visibleIf` condition, 
which removes the field properties from the output model,
the use of the `widget.id` `hidden` with a default value will keep the field property in the output model. 

would be glad to see this coming