### PR TITLE
enabled custom rendering of schema action buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,55 @@ export class AppComponent {
 }
 ```
 
+#### Render buttons
+
+You may define you own widget to create buttons by 
+overriding the default widget for action buttons
+or create completely customized button widgets.
+
+##### Override
+
+Override the default action button widget 
+in your `WidgetRegistry` implementation
+and register your own button widget.
+
+```js
+    this.register('button', MyButtonWidgetComponent);
+```
+
+##### Custom
+
+Define a custom button widget by 
+setting the property `button.widget` in the schema
+
+```json
+    "password": {
+      "type": "string",
+      "description": "Password",
+      "buttons": [{
+        "id": "reset",
+        "label": "Reset"
+      },{
+        "id": "custom_b",
+        "label": "My custom button",
+        "widget": "my_custom_button" // custom widget name for this button
+      }]
+    },
+``` 
+
+and then register it in your `WidgetRegistry` implementation
+
+```js
+    this.register('my_custom_button', MyCustomButtonWidgetComponent);
+```
+  
+##### Binding
+
+The button widget will get provided the `button` object form the schema
+including the `button.action` from the action registry 
+and the `formProperty` object.
+
+
 ### Advanced validation
 JSON schema provides validation against a static schema but its often necessary to provide other validation rules.
 The Form component accepts a `validators` input bound to a map between a field id and a validation function.

--- a/src/defaultwidgets/button/button.widget.ts
+++ b/src/defaultwidgets/button/button.widget.ts
@@ -1,0 +1,9 @@
+import {Component} from "@angular/core";
+
+@Component({
+  selector: 'sf-button-widget',
+  template: '<button (click)="button.action($event)">{{button.label}}</button>'
+})
+export class ButtonWidget {
+
+}

--- a/src/defaultwidgets/index.ts
+++ b/src/defaultwidgets/index.ts
@@ -8,4 +8,5 @@ export { RangeWidget } from './range/range.widget';
 export { SelectWidget } from './select/select.widget';
 export { StringWidget } from './string/string.widget';
 export { TextAreaWidget } from './textarea/textarea.widget';
+export { ButtonWidget } from './button/button.widget';
 export { DefaultWidgetRegistry } from './defaultwidgetregistry';

--- a/src/formelement.action.component.ts
+++ b/src/formelement.action.component.ts
@@ -1,0 +1,39 @@
+import {Component, ComponentRef, Input, OnChanges, ViewChild, ViewContainerRef} from "@angular/core";
+import {WidgetFactory} from "./widgetfactory";
+import {TerminatorService} from "./terminator.service";
+
+@Component({
+  selector: 'sf-form-element-action',
+  template: '<ng-template #target></ng-template>'
+})
+export class FormElementComponentAction implements OnChanges {
+
+  @Input()
+  button: any
+
+  @Input()
+  formProperty: any
+
+  @ViewChild('target', {read: ViewContainerRef}) container: ViewContainerRef;
+
+  private ref: ComponentRef<any>;
+
+  constructor(private widgetFactory: WidgetFactory = null,
+              private terminator: TerminatorService) {
+  }
+
+  ngOnInit() {
+    this.terminator.onDestroy.subscribe(destroy => {
+      if (destroy) {
+        this.ref.destroy();
+      }
+    })
+  }
+
+  ngOnChanges() {
+    this.ref = this.widgetFactory.createWidget(this.container, this.button.widget || 'button');
+    this.ref.instance.button = this.button
+    this.ref.instance.formProperty = this.formProperty
+  }
+
+}

--- a/src/formelement.component.ts
+++ b/src/formelement.component.ts
@@ -24,7 +24,7 @@ import {
 	(widgetInstanciated)="onWidgetInstanciated($event)"
 	[widgetInfo]="formProperty.schema.widget">
 	</sf-widget-chooser>
-	<button *ngFor="let button of buttons" (click)="button.action($event)">{{button.label}}</button>
+	<sf-form-element-action *ngFor="let button of buttons" [button]="button" [formProperty]="formProperty"></sf-form-element-action>
 </div>`
 })
 export class FormElementComponent implements OnInit {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { FormComponent } from './form.component';
 export { FormElementComponent } from './formelement.component';
+export {FormElementComponentAction} from './formelement.action.component'
 export { WidgetChooserComponent } from './widgetchooser.component';
 export { WidgetRegistry } from './widgetregistry';
 export { Validator } from './model/validator';

--- a/src/schema-form.module.ts
+++ b/src/schema-form.module.ts
@@ -27,11 +27,13 @@ import {
 import { WidgetRegistry } from './widgetregistry';
 import { DefaultWidgetRegistry } from './defaultwidgets';
 import { SchemaValidatorFactory, ZSchemaValidatorFactory } from './schemavalidatorfactory';
+import {FormElementComponentAction} from "./formelement.action.component";
 
 @NgModule({
   imports : [CommonModule, FormsModule, ReactiveFormsModule],
   declarations: [
     FormElementComponent,
+    FormElementComponentAction,
     FormComponent,
     WidgetChooserComponent,
     DefaultWidget,
@@ -48,6 +50,7 @@ import { SchemaValidatorFactory, ZSchemaValidatorFactory } from './schemavalidat
   ],
   entryComponents: [
     FormElementComponent,
+    FormElementComponentAction,
     FormComponent,
     WidgetChooserComponent,
     ArrayWidget,
@@ -64,6 +67,7 @@ import { SchemaValidatorFactory, ZSchemaValidatorFactory } from './schemavalidat
   exports: [
     FormComponent,
     FormElementComponent,
+    FormElementComponentAction,
     WidgetChooserComponent,
     ArrayWidget,
     ObjectWidget,


### PR DESCRIPTION
# Rendering Action Buttons 

The `WidgetRegistry` now can also create the buttons for the schema actions.
This allows to keep the buttons in the same style as the other widget (Bootstrap, Material ...etc).

Since I couldn't see any obvious reason to create an extra registry I did extend the `DefaultWidgetRegistry` to provide also the button-widgets.

Would be glad to see this coming

--------
**Example image of custom rendered action buttons**

<img width="217" alt="render-custom-action-buttons" src="https://user-images.githubusercontent.com/2026072/29063691-ef45ff3a-7c26-11e7-9d76-fe3256b3db22.png">