### PR TITLE
Result object reduced only to visible and dirty properties

### DIFF
--- a/src/model/arrayproperty.ts
+++ b/src/model/arrayproperty.ts
@@ -1,18 +1,16 @@
-import { FormProperty, PropertyGroup } from './formproperty';
-import { FormPropertyFactory } from './formpropertyfactory';
-import { SchemaValidatorFactory } from '../schemavalidatorfactory';
-import { ValidatorRegistry } from './validatorregistry';
+import {FormProperty, PropertyGroup} from './formproperty';
+import {FormPropertyFactory} from './formpropertyfactory';
+import {SchemaValidatorFactory} from '../schemavalidatorfactory';
+import {ValidatorRegistry} from './validatorregistry';
 
 export class ArrayProperty extends PropertyGroup {
 
-  constructor(
-    private formPropertyFactory: FormPropertyFactory,
-    schemaValidatorFactory: SchemaValidatorFactory,
-    validatorRegistry: ValidatorRegistry,
-    schema: any,
-    parent: PropertyGroup,
-    path: string
-  ) {
+  constructor(private formPropertyFactory: FormPropertyFactory,
+              schemaValidatorFactory: SchemaValidatorFactory,
+              validatorRegistry: ValidatorRegistry,
+              schema: any,
+              parent: PropertyGroup,
+              path: string) {
     super(schemaValidatorFactory, validatorRegistry, schema, parent, path);
   }
 
@@ -39,14 +37,18 @@ export class ArrayProperty extends PropertyGroup {
     this.updateValueAndValidity(onlySelf, true);
   }
 
+  public _hasValue(): boolean {
+    return true;
+  }
+
   public _updateValue() {
     this.reduceValue();
   }
 
   private reduceValue(): void {
-    let value = [];
+    const value = [];
     this.forEachChild((property, _) => {
-      if (property.visible) {
+      if (property.visible && property._hasValue()) {
         value.push(property.value);
       }
     });
@@ -73,5 +75,4 @@ export class ArrayProperty extends PropertyGroup {
       }
     }
   }
-
 }

--- a/src/model/atomicproperties.spec.ts
+++ b/src/model/atomicproperties.spec.ts
@@ -61,24 +61,9 @@ describe('Atomic properties', () => {
 
   describe('NumberProperty', () => {
 
-    let AN_INT_PROPERTY_SCHEMA_WITH_MINIMUM = {'type': 'number', 'minimum': 10};
     let AN_INT_PROPERTY_SCHEMA_WITHOUT_MINIMUM = {'type': 'number'};
 
-    it('with minimum in schema should fallback to minimum on reset', () => {
-      let property = new NumberProperty(
-        A_SCHEMA_VALIDATOR_FACTORY,
-        A_VALIDATOR_REGISTRY,
-        AN_INT_PROPERTY_SCHEMA_WITH_MINIMUM,
-        null,
-        ''
-      );
-
-      property.reset();
-
-      expect(property.value).toBe(AN_INT_PROPERTY_SCHEMA_WITH_MINIMUM.minimum);
-    });
-
-    it('without minimum in schema should fallback to 0 on reset', () => {
+    it('without minimum in schema should fallback to null on reset', () => {
       let property = new NumberProperty(
         A_SCHEMA_VALIDATOR_FACTORY,
         A_VALIDATOR_REGISTRY,
@@ -89,7 +74,7 @@ describe('Atomic properties', () => {
 
       property.reset();
 
-      expect(property.value).toBe(0);
+      expect(property.value).toBe(null);
     });
   });
 });

--- a/src/model/atomicproperty.ts
+++ b/src/model/atomicproperty.ts
@@ -1,4 +1,4 @@
-import { FormProperty } from './formproperty';
+import {FormProperty} from './formproperty';
 
 export abstract class AtomicProperty extends FormProperty {
 
@@ -17,14 +17,18 @@ export abstract class AtomicProperty extends FormProperty {
       if (this.schema.default !== undefined) {
         value = this.schema.default;
       } else {
-      value = this.fallbackValue();
+        value = this.fallbackValue();
       }
     }
     this._value = value;
   }
 
+  public _hasValue(): boolean {
+    return this.fallbackValue() !== this.value;
+  }
+
   abstract fallbackValue(): any;
 
-  public _updateValue() {};
-
+  public _updateValue() {
+  }
 }

--- a/src/model/booleanproperty.ts
+++ b/src/model/booleanproperty.ts
@@ -3,7 +3,6 @@ import { AtomicProperty } from './atomicproperty';
 export class BooleanProperty extends AtomicProperty {
 
   fallbackValue() {
-    return false;
+    return null;
   }
-
 }

--- a/src/model/formproperty.ts
+++ b/src/model/formproperty.ts
@@ -1,19 +1,19 @@
-import { Observable } from 'rxjs/Observable';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import {Observable} from 'rxjs/Observable';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import 'rxjs/add/observable/combineLatest';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/distinctUntilChanged';
 
-import { SchemaValidatorFactory } from '../schemavalidatorfactory';
-import { ValidatorRegistry } from './validatorregistry';
+import {SchemaValidatorFactory} from '../schemavalidatorfactory';
+import {ValidatorRegistry} from './validatorregistry';
 
 export abstract class FormProperty {
   public schemaValidator: Function;
   private _required: boolean;
 
   _value: any = null;
-  _errors: any = null ;
+  _errors: any = null;
   private _valueChanges = new BehaviorSubject<any>(null);
   private _errorsChanges = new BehaviorSubject<any>(null);
   private _visible = true;
@@ -22,14 +22,11 @@ export abstract class FormProperty {
   private _parent: PropertyGroup;
   private _path: string;
 
-  constructor(
-    schemaValidatorFactory: SchemaValidatorFactory,
-    private validatorRegistry: ValidatorRegistry,
-    public schema: any,
-
-    parent: PropertyGroup,
-    path: string
-  ) {
+  constructor(schemaValidatorFactory: SchemaValidatorFactory,
+              private validatorRegistry: ValidatorRegistry,
+              public schema: any,
+              parent: PropertyGroup,
+              path: string) {
     this.schemaValidator = schemaValidatorFactory.createValidatorFn(this.schema);
 
     this._parent = parent;
@@ -46,7 +43,7 @@ export abstract class FormProperty {
   private _isRequired() {
     if (!this._parent)
       return false;
-    return -1 != (this._parent.schema.required || []).indexOf(this._path.split('/').slice(-1)[0])
+    return -1 !== (this._parent.schema.required || []).indexOf(this._path.split('/').slice(-1)[0]);
   }
 
   public get required(): boolean {
@@ -91,7 +88,7 @@ export abstract class FormProperty {
 
   public abstract setValue(value: any, onlySelf: boolean);
 
-  public abstract reset(value: any, onlySelf: boolean)
+  public abstract reset(value: any, onlySelf: boolean);
 
   public updateValueAndValidity(onlySelf = false, emitEvent = true) {
     this._updateValue();
@@ -109,6 +106,11 @@ export abstract class FormProperty {
   }
 
   /**
+   * @internal
+   */
+  public abstract _hasValue(): boolean;
+
+  /**
    *  @internal
    */
   public abstract _updateValue();
@@ -120,7 +122,7 @@ export abstract class FormProperty {
     let errors = this.schemaValidator(this._value) || [];
     let customValidator = this.validatorRegistry.get(this.path);
     if (customValidator) {
-      let customErrors = customValidator(this.value, this, this.findRoot()) ;
+      let customErrors = customValidator(this.value, this, this.findRoot());
       errors = this.mergeErrors(errors, customErrors);
     }
     if (errors.length === 0) {
@@ -166,7 +168,7 @@ export abstract class FormProperty {
 
   public findRoot(): PropertyGroup {
     let property: FormProperty = this;
-    while (property.parent !== null ) {
+    while (property.parent !== null) {
       property = property.parent;
     }
     return <PropertyGroup>property;
@@ -184,8 +186,7 @@ export abstract class FormProperty {
   // A field is visible if AT LEAST ONE of the properties it depends on is visible AND has a value in the list
   public _bindVisibility() {
     let visibleIf = this.schema.visibleIf;
-    if (typeof visibleIf === 'object' && Object.keys(visibleIf).length === 0)
-    {
+    if (typeof visibleIf === 'object' && Object.keys(visibleIf).length === 0) {
       this.setVisible(false);
     }
     else if (visibleIf !== undefined) {
@@ -198,7 +199,7 @@ export abstract class FormProperty {
               value => {
                 if (visibleIf[dependencyPath].indexOf('$ANY$') !== -1) {
                   return value.length > 0;
-                }else {
+                } else {
                   return visibleIf[dependencyPath].indexOf(value) !== -1;
                 }
               }
@@ -223,11 +224,11 @@ export abstract class FormProperty {
 
 export abstract class PropertyGroup extends FormProperty {
 
-  properties: FormProperty[] | {[key: string]: FormProperty} = null;
+  properties: FormProperty[] | { [key: string]: FormProperty } = null;
 
   getProperty(path: string) {
     let subPathIdx = path.indexOf('/');
-    let propertyId = subPathIdx !== -1 ? path.substr(0, subPathIdx) : path ;
+    let propertyId = subPathIdx !== -1 ? path.substr(0, subPathIdx) : path;
 
     let property = this.properties[propertyId];
     if (property !== null && subPathIdx !== -1 && property instanceof PropertyGroup) {
@@ -260,7 +261,7 @@ export abstract class PropertyGroup extends FormProperty {
     this._bindVisibilityRecursive();
   }
 
-  private _bindVisibilityRecursive () {
+  private _bindVisibilityRecursive() {
     this.forEachChildRecursive((property) => {
       property._bindVisibility();
     });

--- a/src/model/formproperty.ts
+++ b/src/model/formproperty.ts
@@ -10,7 +10,6 @@ import {ValidatorRegistry} from './validatorregistry';
 
 export abstract class FormProperty {
   public schemaValidator: Function;
-  private _required: boolean;
 
   _value: any = null;
   _errors: any = null;
@@ -36,18 +35,6 @@ export abstract class FormProperty {
       this._root = <PropertyGroup><any>this;
     }
     this._path = path;
-
-    this._required = this._isRequired();
-  }
-
-  private _isRequired() {
-    if (!this._parent)
-      return false;
-    return -1 !== (this._parent.schema.required || []).indexOf(this._path.split('/').slice(-1)[0]);
-  }
-
-  public get required(): boolean {
-    return this._required;
   }
 
   public get valueChanges() {
@@ -147,6 +134,11 @@ export abstract class FormProperty {
   private setErrors(errors) {
     this._errors = errors;
     this._errorsChanges.next(errors);
+  }
+
+  public extendErrors(errors) {
+    errors = this.mergeErrors(this._errors || [], errors);
+    this.setErrors(errors);
   }
 
   searchProperty(path: string): FormProperty {

--- a/src/model/numberproperty.ts
+++ b/src/model/numberproperty.ts
@@ -1,20 +1,18 @@
-import { AtomicProperty } from './atomicproperty';
+import {AtomicProperty} from './atomicproperty';
 
 export class NumberProperty extends AtomicProperty {
 
   fallbackValue() {
-    let value;
-    if (this.schema.minimum !== undefined) {
-      value = this.schema.minimum;
-    } else {
-      value = 0;
-    }
-    return value;
+    return null;
   }
 
   setValue(value, onlySelf = false) {
     if (typeof value === 'string') {
-       value = value.indexOf('.') > -1 ? parseFloat(value) : parseInt(value, 10);
+      if (value.length) {
+        value = value.indexOf('.') > -1 ? parseFloat(value) : parseInt(value, 10);
+      } else {
+        value = null;
+      }
     }
     this._value = value;
     this.updateValueAndValidity(onlySelf, true);

--- a/src/model/objectproperty.ts
+++ b/src/model/objectproperty.ts
@@ -60,6 +60,17 @@ export class ObjectProperty extends PropertyGroup {
     this.reduceValue();
   }
 
+  public _runValidation() {
+    super._runValidation();
+
+    if (this._errors) {
+      this._errors.forEach(error => {
+        const prop = this.searchProperty(error.path.slice(1));
+        prop.extendErrors(error);
+      });
+    }
+  }
+
   private reduceValue(): void {
     const value = {};
     this.forEachChild((property, propertyId: string) => {

--- a/src/model/objectproperty.ts
+++ b/src/model/objectproperty.ts
@@ -66,7 +66,9 @@ export class ObjectProperty extends PropertyGroup {
     if (this._errors) {
       this._errors.forEach(error => {
         const prop = this.searchProperty(error.path.slice(1));
-        prop.extendErrors(error);
+        if (prop) {
+          prop.extendErrors(error);
+        }
       });
     }
   }

--- a/src/model/objectproperty.ts
+++ b/src/model/objectproperty.ts
@@ -1,26 +1,24 @@
-import { PropertyGroup } from './formproperty';
-import { FormPropertyFactory } from './formpropertyfactory';
-import { SchemaValidatorFactory } from '../schemavalidatorfactory';
-import { ValidatorRegistry } from './validatorregistry';
+import {PropertyGroup} from './formproperty';
+import {FormPropertyFactory} from './formpropertyfactory';
+import {SchemaValidatorFactory} from '../schemavalidatorfactory';
+import {ValidatorRegistry} from './validatorregistry';
 
 export class ObjectProperty extends PropertyGroup {
 
-  private propertiesId: string[]= [];
+  private propertiesId: string[] = [];
 
-  constructor(
-    private formPropertyFactory: FormPropertyFactory,
-    schemaValidatorFactory: SchemaValidatorFactory,
-    validatorRegistry: ValidatorRegistry,
-    schema: any,
-    parent: PropertyGroup,
-    path: string
-  ) {
+  constructor(private formPropertyFactory: FormPropertyFactory,
+              schemaValidatorFactory: SchemaValidatorFactory,
+              validatorRegistry: ValidatorRegistry,
+              schema: any,
+              parent: PropertyGroup,
+              path: string) {
     super(schemaValidatorFactory, validatorRegistry, schema, parent, path);
     this.createProperties();
   }
 
   setValue(value: any, onlySelf: boolean) {
-    for (let propertyId in value) {
+    for (const propertyId in value) {
       if (value.hasOwnProperty(propertyId)) {
         this.properties[propertyId].setValue(value[propertyId], true);
       }
@@ -35,7 +33,7 @@ export class ObjectProperty extends PropertyGroup {
   }
 
   resetProperties(value: any) {
-    for (let propertyId in this.schema.properties) {
+    for (const propertyId in this.schema.properties) {
       if (this.schema.properties.hasOwnProperty(propertyId)) {
         this.properties[propertyId].reset(value[propertyId], true);
       }
@@ -45,14 +43,17 @@ export class ObjectProperty extends PropertyGroup {
   createProperties() {
     this.properties = {};
     this.propertiesId = [];
-    for (let propertyId in this.schema.properties) {
+    for (const propertyId in this.schema.properties) {
       if (this.schema.properties.hasOwnProperty(propertyId)) {
-        let propertySchema = this.schema.properties[propertyId];
-        let property = this.formPropertyFactory.createProperty(propertySchema, this, propertyId);
-        this.properties[propertyId] = property;
+        const propertySchema = this.schema.properties[propertyId];
+        this.properties[propertyId] = this.formPropertyFactory.createProperty(propertySchema, this, propertyId);
         this.propertiesId.push(propertyId);
       }
     }
+  }
+
+  public _hasValue(): boolean {
+    return !!Object.keys(this.value).length;
   }
 
   public _updateValue() {
@@ -60,13 +61,12 @@ export class ObjectProperty extends PropertyGroup {
   }
 
   private reduceValue(): void {
-    let value = {};
+    const value = {};
     this.forEachChild((property, propertyId: string) => {
-      if (property.visible) {
+      if (property.visible && property._hasValue()) {
         value[propertyId] = property.value;
       }
     });
     this._value = value;
   }
-
 }

--- a/src/model/schemapreprocessor.ts
+++ b/src/model/schemapreprocessor.ts
@@ -21,7 +21,7 @@ export class SchemaPreprocessor {
     if (jsonSchema.type === 'object') {
       SchemaPreprocessor.checkProperties(jsonSchema, path);
       SchemaPreprocessor.checkAndCreateFieldsets(jsonSchema, path);
-      SchemaPreprocessor.normalizeRequired(jsonSchema);
+      // SchemaPreprocessor.normalizeRequired(jsonSchema);
     } else if (jsonSchema.type === 'array') {
       SchemaPreprocessor.checkItems(jsonSchema, path);
     }

--- a/src/model/schemapreprocessor.ts
+++ b/src/model/schemapreprocessor.ts
@@ -21,7 +21,6 @@ export class SchemaPreprocessor {
     if (jsonSchema.type === 'object') {
       SchemaPreprocessor.checkProperties(jsonSchema, path);
       SchemaPreprocessor.checkAndCreateFieldsets(jsonSchema, path);
-      // SchemaPreprocessor.normalizeRequired(jsonSchema);
     } else if (jsonSchema.type === 'array') {
       SchemaPreprocessor.checkItems(jsonSchema, path);
     }
@@ -104,12 +103,6 @@ export class SchemaPreprocessor {
       widget = {'id': widget};
     }
     fieldSchema.widget = widget;
-  }
-
-  private static normalizeRequired(jsonSchema) {
-    if (jsonSchema.type === 'object' && jsonSchema.required === undefined) {
-      jsonSchema.required = Object.keys(jsonSchema.properties);
-    }
   }
 
   private static checkItems(jsonSchema, path) {

--- a/src/schema-form.module.ts
+++ b/src/schema-form.module.ts
@@ -1,13 +1,13 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {CommonModule} from '@angular/common';
 import {
   FormsModule,
   ReactiveFormsModule
 } from '@angular/forms';
 
-import { FormElementComponent } from './formelement.component';
-import { FormComponent } from './form.component';
-import { WidgetChooserComponent } from './widgetchooser.component';
+import {FormElementComponent} from './formelement.component';
+import {FormComponent} from './form.component';
+import {WidgetChooserComponent} from './widgetchooser.component';
 import {
   ArrayWidget,
   ButtonWidget,
@@ -25,13 +25,24 @@ import {
   DefaultWidget
 } from './default.widget';
 
-import { WidgetRegistry } from './widgetregistry';
-import { DefaultWidgetRegistry } from './defaultwidgets';
-import { SchemaValidatorFactory, ZSchemaValidatorFactory } from './schemavalidatorfactory';
+import {WidgetRegistry} from './widgetregistry';
+import {DefaultWidgetRegistry} from './defaultwidgets';
+import {SchemaValidatorFactory, ZSchemaValidatorFactory} from './schemavalidatorfactory';
 import {FormElementComponentAction} from "./formelement.action.component";
 
+const moduleProviders = [
+  {
+    provide: WidgetRegistry,
+    useClass: DefaultWidgetRegistry
+  },
+  {
+    provide: SchemaValidatorFactory,
+    useClass: ZSchemaValidatorFactory
+  }
+];
+
 @NgModule({
-  imports : [CommonModule, FormsModule, ReactiveFormsModule],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule],
   declarations: [
     FormElementComponent,
     FormElementComponentAction,
@@ -85,20 +96,18 @@ import {FormElementComponentAction} from "./formelement.action.component";
 })
 export class SchemaFormModule {
 
-  static forRoot(): ModuleWithProviders {
+  static forRoot(providers?: [{ provide: any, useClass: any }]): ModuleWithProviders {
+    if (providers) {
+      providers.forEach(provider => {
+        const found = moduleProviders.find(p => p.provide === provider.provide);
+        found.useClass = provider.useClass;
+      });
+    }
+
     return {
       ngModule: SchemaFormModule,
-      providers: [
-        {
-          provide: WidgetRegistry,
-          useClass: DefaultWidgetRegistry
-        },
-        {
-          provide: SchemaValidatorFactory,
-          useClass: ZSchemaValidatorFactory
-        }
-      ]
-    }
+      providers: [...moduleProviders]
+    };
   }
 
 }

--- a/src/schemavalidatorfactory.ts
+++ b/src/schemavalidatorfactory.ts
@@ -22,7 +22,21 @@ export class ZSchemaValidatorFactory extends SchemaValidatorFactory {
 
       this.zschema.validate(value, schema);
       let err = this.zschema.getLastErrors();
+
+      this.denormalizeRequiredPropertyPaths(err);
+
       return err || null;
     };
+  }
+
+  private denormalizeRequiredPropertyPaths(err: any[]) {
+    if (err && err.length) {
+      err = err.map(error => {
+        if (error.path === '#/' && error.code === 'OBJECT_MISSING_REQUIRED_PROPERTY') {
+          error.path = `${error.path}${error.params[0]}`;
+        }
+        return error;
+      });
+    }
   }
 }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1,6 +1,6 @@
-import { AfterViewInit } from '@angular/core';
-import { FormControl } from '@angular/forms';
-import { ArrayProperty, FormProperty, ObjectProperty } from './model';
+import {AfterViewInit} from '@angular/core';
+import {FormControl} from '@angular/forms';
+import {ArrayProperty, FormProperty, ObjectProperty} from './model';
 
 export abstract class Widget<T extends FormProperty> {
   formProperty: T;
@@ -14,7 +14,7 @@ export abstract class Widget<T extends FormProperty> {
 export class ControlWidget extends Widget<FormProperty> implements AfterViewInit {
 
   ngAfterViewInit() {
-    let control = this.control;
+    const control = this.control;
     this.formProperty.valueChanges.subscribe((newValue) => {
       if (control.value !== newValue) {
         control.setValue(newValue, {emitEvent: false});
@@ -23,11 +23,29 @@ export class ControlWidget extends Widget<FormProperty> implements AfterViewInit
     this.formProperty.errorsChanges.subscribe((errors) => {
       control.setErrors(errors, {emitEvent: true});
     });
-    control.valueChanges.subscribe((newValue) => { this.formProperty.setValue(newValue, false); });
+    control.valueChanges.subscribe((newValue) => {
+      this.formProperty.setValue(newValue, false);
+    });
   }
 
 }
 
-export class ArrayLayoutWidget extends Widget<ArrayProperty> {}
+export class ArrayLayoutWidget extends Widget<ArrayProperty> implements AfterViewInit {
 
-export class ObjectLayoutWidget extends Widget<ObjectProperty> {}
+  ngAfterViewInit() {
+    const control = this.control;
+    this.formProperty.errorsChanges.subscribe((errors) => {
+      control.setErrors(errors, {emitEvent: true});
+    });
+  }
+}
+
+export class ObjectLayoutWidget extends Widget<ObjectProperty> implements AfterViewInit {
+
+  ngAfterViewInit() {
+    const control = this.control;
+    this.formProperty.errorsChanges.subscribe((errors) => {
+      control.setErrors(errors, {emitEvent: true});
+    });
+  }
+}


### PR DESCRIPTION
On the result object the properties appears when it's value is other than fallback value.

Why?
This is expected due to the JSON schema required property validation. If the result object properties fills out with fallback values we lost the ability to check the property is present (required) or not.

Example of its earlier operation:
```
const schema = {
    "type": "object",
    "required": ["foo"],
    "properties": {
      "foo": {
        "type": "string"
      }
    }
  }
```
```
const result = {
  foo: ""
}
```
In  this case the result object is valid. The only thing what we can do to prevent submit the empty form is  to supplement the schema with "minLength": 1

The expected result in the example above is:
```
const result = {}
```
In this case the validator will warn you of the missing (required) property. Object is going to be valid after you fill out the input.

After that the `SchemaPreprocessor.normalizeRequired()` function is purposeless. I don't know why we transform a valid JSON schema to a schema which produces an invalid operation?
