### PR TITLE
deep $ref support for definitions

### DIFF
--- a/src/model/formpropertyfactory.ts
+++ b/src/model/formpropertyfactory.ts
@@ -1,14 +1,16 @@
-import { FormProperty, PropertyGroup } from './formproperty';
-import { NumberProperty } from './numberproperty';
-import { StringProperty } from './stringproperty';
-import { BooleanProperty } from './booleanproperty';
-import { ObjectProperty } from './objectproperty';
-import { ArrayProperty } from './arrayproperty';
-import { SchemaValidatorFactory } from '../schemavalidatorfactory';
-import { ValidatorRegistry } from './validatorregistry';
+import {FormProperty, PropertyGroup} from './formproperty';
+import {NumberProperty} from './numberproperty';
+import {StringProperty} from './stringproperty';
+import {BooleanProperty} from './booleanproperty';
+import {ObjectProperty} from './objectproperty';
+import {ArrayProperty} from './arrayproperty';
+import {SchemaValidatorFactory} from '../schemavalidatorfactory';
+import {ValidatorRegistry} from './validatorregistry';
 
 export class FormPropertyFactory {
-  constructor(private schemaValidatorFactory: SchemaValidatorFactory, private validatorRegistry: ValidatorRegistry) {}
+  constructor(private schemaValidatorFactory: SchemaValidatorFactory, private validatorRegistry: ValidatorRegistry) {
+  }
+
   createProperty(schema: any, parent: PropertyGroup = null, propertyId?: string): FormProperty {
     let newProperty = null;
     let path = '';
@@ -28,25 +30,30 @@ export class FormPropertyFactory {
       path = '/';
     }
 
-    switch (schema.type) {
-      case 'integer':
-      case 'number':
-        newProperty = new NumberProperty(this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
-      break;
-      case 'string':
-        newProperty = new StringProperty(this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
-      break;
-      case 'boolean':
-        newProperty = new BooleanProperty(this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
-      break;
-      case 'object':
-        newProperty = new ObjectProperty(this, this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
-      break;
-      case 'array':
-        newProperty = new ArrayProperty(this, this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
-      break;
-      default:
-        throw new TypeError(`Undefined type ${schema.type}`);
+    if (schema.$ref) {
+      const refSchema = this.schemaValidatorFactory.getSchema(parent.root.schema, schema.$ref);
+      newProperty = this.createProperty(refSchema, parent, path);
+    } else {
+      switch (schema.type) {
+        case 'integer':
+        case 'number':
+          newProperty = new NumberProperty(this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
+          break;
+        case 'string':
+          newProperty = new StringProperty(this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
+          break;
+        case 'boolean':
+          newProperty = new BooleanProperty(this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
+          break;
+        case 'object':
+          newProperty = new ObjectProperty(this, this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
+          break;
+        case 'array':
+          newProperty = new ArrayProperty(this, this.schemaValidatorFactory, this.validatorRegistry, schema, parent, path);
+          break;
+        default:
+          throw new TypeError(`Undefined type ${schema.type}`);
+      }
     }
 
     if (newProperty instanceof PropertyGroup) {

--- a/src/model/schemapreprocessor.ts
+++ b/src/model/schemapreprocessor.ts
@@ -1,4 +1,4 @@
-import { isBlank } from './utils';
+import {isBlank} from './utils';
 
 function formatMessage(message, path) {
   return `Parsing error on ${path}: ${message}`;
@@ -51,7 +51,7 @@ export class SchemaPreprocessor {
     let usedFields = {};
     for (let fieldset of jsonSchema.fieldsets) {
       for (let fieldId of fieldset.fields) {
-        if (usedFields[fieldId] === undefined ) {
+        if (usedFields[fieldId] === undefined) {
           usedFields[fieldId] = [];
         }
         usedFields[fieldId].push(fieldset.id);
@@ -64,11 +64,11 @@ export class SchemaPreprocessor {
           schemaError(`${fieldId} is referenced by more than one fieldset: ${usedFields[fieldId]}`, path);
         }
         delete usedFields[fieldId];
-      } else if (jsonSchema.required.indexOf(fieldId) > -1 ) {
+      } else if (jsonSchema.required.indexOf(fieldId) > -1) {
         schemaError(`${fieldId} is a required field but it is not referenced as part of a 'order' or a 'fieldset' property`, path);
       } else {
         delete jsonSchema[fieldId];
-          schemaWarning(`Removing unreferenced field ${fieldId}`, path);
+        schemaWarning(`Removing unreferenced field ${fieldId}`, path);
       }
     }
 
@@ -88,8 +88,8 @@ export class SchemaPreprocessor {
     jsonSchema.fieldsets = [{
       id: 'fieldset-default',
       title: jsonSchema.title || '',
-      description : jsonSchema.description || '',
-      name : jsonSchema.name || '',
+      description: jsonSchema.description || '',
+      name: jsonSchema.name || '',
       fields: jsonSchema.order
     }];
     delete jsonSchema.order;
@@ -119,7 +119,14 @@ export class SchemaPreprocessor {
           SchemaPreprocessor.preprocess(fieldSchema, path + fieldId + '/');
         }
       }
-
+      if (jsonSchema.hasOwnProperty('definitions')) {
+        for (let fieldId in jsonSchema.definitions) {
+          if (jsonSchema.definitions.hasOwnProperty(fieldId)) {
+            let fieldSchema = jsonSchema.definitions[fieldId];
+            SchemaPreprocessor.preprocess(fieldSchema, path + fieldId + '/');
+          }
+        }
+      }
     } else if (jsonSchema.type === 'array') {
       SchemaPreprocessor.preprocess(jsonSchema.items, path + '*/');
     }

--- a/src/schemavalidatorfactory.ts
+++ b/src/schemavalidatorfactory.ts
@@ -2,6 +2,8 @@ let ZSchema = require('z-schema');
 
 export abstract class SchemaValidatorFactory {
   abstract createValidatorFn(schema): (value: any) => any;
+
+  abstract getSchema(schema, ref): any;
 }
 
 export class ZSchemaValidatorFactory extends SchemaValidatorFactory {
@@ -29,6 +31,16 @@ export class ZSchemaValidatorFactory extends SchemaValidatorFactory {
     };
   }
 
+  getSchema(schema: any, ref: string) {
+    // check definitions are valid
+    const isValid = this.zschema.compileSchema(schema);
+    if (isValid) {
+      return this.getDefinition(schema, ref);
+    } else {
+      throw this.zschema.getLastError();
+    }
+  }
+
   private denormalizeRequiredPropertyPaths(err: any[]) {
     if (err && err.length) {
       err = err.map(error => {
@@ -39,4 +51,15 @@ export class ZSchemaValidatorFactory extends SchemaValidatorFactory {
       });
     }
   }
+
+  private getDefinition(schema: any, ref: string) {
+    let foundSchema = schema;
+    ref.split('/').slice(1).forEach(ptr => {
+      if (ptr) {
+        foundSchema = foundSchema[ptr];
+      }
+    });
+    return foundSchema;
+  }
 }
+


### PR DESCRIPTION
Sadly remote schema definitions not supported yet but static defintions works well. Recursive, self-referencing definitions too.

Example:
```
  {
    type: 'object',
    properties: {
      name: {
        $ref: '#/definitions/stringProp'
      },
      something: {
        type: 'array',
        items: {
          type: 'object',
          properties: {
            name: {
              $ref: '#/definitions/stringProp'
            }
          }
        }
      },
      nodes: {
        type: 'array',
        items: {
          $ref: '#/definitions/nodeItem'
        }
      }
    },
    definitions: {
      stringProp: {
        type: 'string',
        minLength: 3
      },
      nodeItem: {
        type: 'object',
        properties: {
          name: {
            $ref: '#/definitions/stringProp'
          },
          nodes: {
            type: 'array',
            items: {
              $ref: '#/definitions/nodeItem'
            }
          }
        }
      }
    }
  }
```