### PR TITLE
For Angular5 and Typescript 2.4.2

### DIFF
--- a/tests/tslint.json
+++ b/tests/tslint.json
@@ -12,7 +12,7 @@
     "curly": true,
     "eofline": true,
     "forin": true,
-    "import-blacklist": [true, "rxjs"],
+    "import-blacklist": [true, "rxjs", "rxjs/Rx"],
     "import-spacing": true,
     "indent": [
       true,


### PR DESCRIPTION
rxjs/Rx should not be imported anymore