### PR TITLE
fixes #173

### DIFF
--- a/src/form.component.ts
+++ b/src/form.component.ts
@@ -17,7 +17,7 @@ import {
   Validator
 } from './model';
 
-import {SchemaValidatorFactory, ZSchemaValidatorFactory} from './schemavalidatorfactory';
+import {SchemaValidatorFactory} from './schemavalidatorfactory';
 import {WidgetFactory} from './widgetfactory';
 import {TerminatorService} from './terminator.service';
 
@@ -38,9 +38,6 @@ export function useFactory(schemaValidatorFactory, validatorRegistry) {
     SchemaPreprocessor,
     WidgetFactory,
     {
-      provide: SchemaValidatorFactory,
-      useClass: ZSchemaValidatorFactory
-    }, {
       provide: FormPropertyFactory,
       useFactory: useFactory,
       deps: [SchemaValidatorFactory, ValidatorRegistry]


### PR DESCRIPTION
Allow providing SchemaValidatorFactory 2 - FormComponent

The provided `SchemaValidatorFactory` via the module providers is not being used in FormComponent,
since the `SchemaValidatorFactory` is explicitly set to `ZSchemaValidatorFactory`.

To make it work, the declaration of the SchemaValidatorFactory must be removed from the providers, since it is already declared as global provider in `schema-form.module.ts`.